### PR TITLE
feat(BREAKING): add route hooks, replace `fallback` and `validators` exports with `default` and `HOOKS`

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ const VALIDATORS = {
 export const HOOKS = () => {
   return {
     VALIDATORS,
-    someHookFn: () => {}
+    someHookFn: () => null
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ We're currently in the alpha phase of development and welcome contributions. Ple
 Create a new project, then install Vite v6 and xink as dev dependencies.
 
 ```
-bun add -D vite@latest @xinkjs/xink
-deno add -D npm:vite@latest npm:@xinkjs/xink
-[p]npm add -D vite@latest @xinkjs/xink
+bun add -D vite @xinkjs/xink
+deno add -D npm:vite npm:@xinkjs/xink
+[p]npm add -D vite @xinkjs/xink
 ```
 
 ### Vite plugin configuration
@@ -150,9 +150,9 @@ export default {
 
 Routes are created in `src/routes`. Each directory under this path represents a route segment.
 
-At the end of a route path, a javascript or typescript `route` file should export one or more functions for each HTTP method it will serve. You can also define a `fallback`, for any unhandled request methods.
+At the end of a route path, a javascript or typescript `route` file should export one or more functions for each HTTP method it will serve. You can also define a default export, for any unhandled request methods.
 
-xink supports these verbs and function names: 'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'fallback'
+xink supports these route exports: 'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'default'
 
 ### Route Types
 
@@ -179,7 +179,7 @@ export const POST = async ({ request, json }: RequestEvent) => {
   return json(await request.json())
 }
 
-export const fallback = ({ request, text }: RequestEvent) => {
+export default ({ request, text }: RequestEvent) => {
   return text(`Hello ${request.method}`)
 }
 ```
@@ -229,7 +229,7 @@ export const GET = ({ params }) => {
 ```
 
 ## Middleware
-xink uses the same middleware strategy as SvelteKit (ok, we stole it). You export a single function named `handle`. Place your middleware in `src/middleware`, with the main file being `middleware.[js|ts]`.
+xink uses the same middleware strategy as SvelteKit (ok, we stole it). You export a single function named `handle`. Place your middleware in `src/middleware`, with the main file being `middleware.[js|ts]`. This gives you access to both the event (includes the Request) and the Response.
 
 ```ts
 /* src/middleware/middleware.ts */
@@ -280,11 +280,48 @@ const second: Handle = (event, resolve) => {
 export const handle: Handle = sequence(first, second)
 ```
 
+## Route Hooks
+
+You can define hooks for each endpoint. These are called after global middleware but before the route handler. Validation also happens before these are called, so you have access to validated data (see next section).
+
+The `HOOKS` export must be a function, which returns an object of hooks. This is a library preference that ensures all route exports are functions.
+
+- access to `event`; if you change it, then you must return it.
+- no access to the response.
+- can by sync or async functions.
+- are not guaranteed to run in any particular order.
+
+```ts
+/* src/routes/route.ts */
+import logger from 'pino'
+
+export const GET = () => { return new Response('Hello') }
+
+export const HOOKS = () => {
+  return {
+    state: (event: RequestEvent) => {
+      event.locals.state = { some: 'state' }
+
+      return event
+    },
+    log: () => {
+      logger().info('Hello from Pino!')
+    },
+    poki: async (event: RequestEvent) => {
+      const res = await fetch('https://pokeapi.co/api/v2/pokemon/pikachu')
+      event.locals.poki = await res.json()
+
+      return event
+    }
+  }
+}
+```
+
 ## Validation
 
 Validate incoming route data for types `form`, `json`, route `params`, or `query` search params. Validated data is available as an object within `event.valid.[form|json|params|query]`.
 
-Export a `validators` function within your route file. For each handler, define a function that returns an object of validated data for the data type. Any thrown errors can be handled by `handleError()` (see further below).
+Your validators are part of hooks. For each handler, define a function that returns an object of validated data for the data type. Any thrown errors can be handled by `handleError()` (see further below).
 
 In the Zod example below, only json data, which matches your schema, will be available in `event.valid.json`; in this case, for POST requests.
 
@@ -292,12 +329,19 @@ In the Zod example below, only json data, which matches your schema, will be ava
 /* src/routes/route.js */
 import { z } from 'zod'
 
-export const validators = {
+const VALIDATORS = {
   POST: {
     json: (z.object({
       hello: z.string(),
       goodbye: z.number()
     })).parse
+  }
+}
+
+export const HOOKS = () => {
+  return {
+    VALIDATORS,
+    someHookFn: () => {}
   }
 }
 
@@ -335,10 +379,14 @@ type PostTypes = {
   json: v.InferInput<typeof post_json_schema>;
 }
 
-export const validators: Validators = {
+const VALIDATORS: Validators = {
   POST: {
     json: v.parser(post_json_schema)
   }
+}
+
+export const HOOKS = () => {
+  return { VALIDATORS }
 }
 
 export const POST = async (event: RequestEvent<PostTypes>) => {
@@ -565,7 +613,7 @@ interface Validators {
   DELETE?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'query'>;
   HEAD?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'query'>;
   OPTIONS?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'query'>;
-  fallback?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'query'>;
+  default?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'query'>;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ You can define hooks for each endpoint. These are called after global middleware
 The `HOOKS` export must be a function, which returns an object of hooks. This is a library preference that ensures all route exports are functions.
 
 - access to `event`; if you change it, then you must return it.
+- if not returning `event`, you must return `null`.
 - no access to the response.
 - can by sync or async functions.
 - are not guaranteed to run in any particular order.
@@ -306,6 +307,8 @@ export const HOOKS = () => {
     },
     log: () => {
       logger().info('Hello from Pino!')
+
+      return null
     },
     poki: async (event: RequestEvent) => {
       const res = await fetch('https://pokeapi.co/api/v2/pokemon/pikachu')

--- a/index.js
+++ b/index.js
@@ -111,7 +111,10 @@ export async function xink(xink_config) {
           input.push(file)
           break // there should only be one middleware file
         }
-
+        for (const file of new Glob(join(cwd, 'src/error.{js,ts}'), {})) {
+          input.push(file)
+          break // there should only be one error handling file
+        }
         for (const file of entrypoint_glob) {
           input.push(file)
           break // there should only be one entrypoint file

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -12,7 +12,11 @@ export const CONFIG = {
 }
 
 export const ALLOWED_HANDLERS = new Set([
-  'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'fallback', 'validators'
+  'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'default', 'HOOKS'
+])
+
+export const DISALLOWED_METHODS = new Set([
+  'default', 'HOOKS'
 ])
 
 export const MAX_COOKIE_SIZE = 4129

--- a/lib/runtime/fetch.js
+++ b/lib/runtime/fetch.js
@@ -3,6 +3,7 @@
 
 import { parse, serialize } from 'cookie'
 import { isContentType } from './utils.js'
+import { DISALLOWED_METHODS } from '../constants.js'
 
 /* ATTR: SvelteKit */
 /**
@@ -252,10 +253,10 @@ export const resolve = async (event) => {
    */
   if (!event.store) return new Response('Not Found', { status: 404 })
 
-  const handler = event.store[event.request.method] ?? event.store['fallback']
+  const handler = event.store[event.request.method] ?? event.store['default']
 
   if (!handler) {
-    const methods = Object.keys(event.store).filter((m) => m !== 'validators').join(', ')
+    const methods = Object.keys(event.store).filter((m) => !DISALLOWED_METHODS.has(m)).join(', ')
 
     /* We found an endpoint, but the requested method is not configured. */
     return new Response('Method Not Allowed', {
@@ -266,8 +267,9 @@ export const resolve = async (event) => {
     })
   }
 
-  if (event.store.validators && event.store.validators[event.request.method]) {
-    const validators = Object.entries(event.store.validators[event.request.method])
+  const hooks = event.store.HOOKS ? event.store.HOOKS() : null
+  if ((hooks && hooks.VALIDATORS && hooks.VALIDATORS[event.request.method])) {
+    const validators = Object.entries(hooks.VALIDATORS[event.request.method])
     const content_type = event.request.headers.get('Content-Type')
 
     for (let i = 0; i < validators.length; i++) {
@@ -309,6 +311,16 @@ export const resolve = async (event) => {
         }
 
         event.valid.query = v(query_obj)
+      }
+    }
+  }
+
+  if (hooks) {
+    const route_hooks = Object.entries(hooks).filter((h) => h[0] !== 'VALIDATORS')
+
+    for (let h = 0; h < route_hooks.length; h++) {
+      if (typeof route_hooks[h][1] === 'function') {
+        event = route_hooks[h][1](event)
       }
     }
   }

--- a/lib/runtime/fetch.js
+++ b/lib/runtime/fetch.js
@@ -320,7 +320,8 @@ export const resolve = async (event) => {
 
     for (let h = 0; h < route_hooks.length; h++) {
       if (typeof route_hooks[h][1] === 'function') {
-        event = route_hooks[h][1](event)
+        const result = await route_hooks[h][1](event)
+        if (result) event = result
       }
     }
   }

--- a/lib/runtime/internal.js
+++ b/lib/runtime/internal.js
@@ -41,10 +41,9 @@ export const initRouter = async () => {
     const store = router.register(v.path)
 
     handlers.forEach(([method, handler]) => {
-      if (method !== 'validators' && typeof handler !== 'function')
+      if (typeof handler !== 'function')
         throw new Error(`Handler ${method} for route ${v.path} is not a function.`)
-      else if (method === 'validators' && typeof handler !== 'object')
-        throw new Error('validators must be an object')
+
       if (!ALLOWED_HANDLERS.has(method))
         throw new Error(`xink does not support the ${method} endpoint handler, found in ${v.file}`)
 

--- a/lib/utils/manifest.js
+++ b/lib/utils/manifest.js
@@ -149,10 +149,8 @@ export const createManifest = async (runner, config) => {
       if (!ALLOWED_HANDLERS.has(key))
         throw new Error(`xink does not support the ${key} endpoint handler, found in ${src_endpoint_path}`)
 
-      if (key !== 'validators' && typeof value !== 'function')
+      if (typeof value !== 'function')
         throw new Error(`Handler ${key} for ${path} is not a function.`)
-      else if (key === 'validators' && typeof value !== 'object')
-        throw new Error('validators must be an object')
     })
 
     manifest.routes[dev_endpoint_path] = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xinkjs/xink",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/xinkjs/xink.git"

--- a/types.d.ts
+++ b/types.d.ts
@@ -53,7 +53,7 @@ export interface Validators {
   DELETE?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
   HEAD?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
   OPTIONS?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
-  fallback?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  default?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
 }
 export type XinkConfig = {
   runtime: 'bun' | 'cloudflare' | 'deno';


### PR DESCRIPTION
This is a major breaking change if you use the `fallback` default handler or `validators`. I thought about deprecating them instead of just ripping them out, but we're in alpha, so. These exports have been removed.

We've replaced the "fallback" export with `export default`. This just makes more sense to me, and eliminates a "magic" export.
We've replaced the "validators" export with the `HOOKS` export (see readme docs). Still a magic export, but since our validation process is augmenting the `event`, it makes sense to place it here.

- breaking: replace exports mentioned above (https://github.com/xinkjs/xink/commit/b0199ab8ba9d94e427b662efe1160775231fc9ea)
- feat: add route `HOOKS` export (https://github.com/xinkjs/xink/commit/b0199ab8ba9d94e427b662efe1160775231fc9ea)