### PR TITLE
breaking: HOOKS export must be an object

### DIFF
--- a/lib/runtime/fetch.js
+++ b/lib/runtime/fetch.js
@@ -344,7 +344,7 @@ export const resolve = async (event) => {
     }
   }
 
-  const hooks = event.store.HOOKS ? event.store.HOOKS() : null
+  const hooks = event.store.HOOKS ?? null
 
   if (hooks?.VALIDATORS?.[event.request.method]) {
     const validators = Object.entries(hooks.VALIDATORS[event.request.method])

--- a/lib/runtime/fetch.js
+++ b/lib/runtime/fetch.js
@@ -346,6 +346,9 @@ export const resolve = async (event) => {
 
   const hooks = event.store.HOOKS ?? null
 
+  if (typeof hooks !== 'object')
+    return await handler(event)
+
   if (hooks?.VALIDATORS?.[event.request.method]) {
     const validators = Object.entries(hooks.VALIDATORS[event.request.method])
     await validation(validators)

--- a/lib/runtime/internal.js
+++ b/lib/runtime/internal.js
@@ -41,7 +41,7 @@ export const initRouter = async () => {
     const store = router.register(v.path)
 
     handlers.forEach(([method, handler]) => {
-      if (typeof handler !== 'function')
+      if (typeof handler !== 'function' && method !== 'HOOKS')
         throw new Error(`Handler ${method} for route ${v.path} is not a function.`)
 
       if (!ALLOWED_HANDLERS.has(method))

--- a/lib/utils/manifest.js
+++ b/lib/utils/manifest.js
@@ -144,13 +144,18 @@ export const createManifest = async (runner, config) => {
      */
     const handlers = Object.entries(module)
 
-    /* Ensure endpoint handlers are valid functions. */
+    /* Ensure endpoint handlers are valid functions, and HOOKS is an object. */
     handlers.forEach(([key, value]) => {
       if (!ALLOWED_HANDLERS.has(key))
         throw new Error(`xink does not support the ${key} endpoint handler, found in ${src_endpoint_path}`)
 
       if (typeof value !== 'function' && key !== 'HOOKS')
         throw new Error(`Handler ${key} for ${path} is not a function.`)
+
+      if (key === 'HOOKS' && typeof value !== 'object')
+        throw new Error(`HOOKS export for ${path} must be an object`)
+
+      console.log(`type of ${key} is ${typeof value}`)
     })
 
     manifest.routes[dev_endpoint_path] = {

--- a/lib/utils/manifest.js
+++ b/lib/utils/manifest.js
@@ -149,7 +149,7 @@ export const createManifest = async (runner, config) => {
       if (!ALLOWED_HANDLERS.has(key))
         throw new Error(`xink does not support the ${key} endpoint handler, found in ${src_endpoint_path}`)
 
-      if (typeof value !== 'function')
+      if (typeof value !== 'function' && key !== 'HOOKS')
         throw new Error(`Handler ${key} for ${path} is not a function.`)
     })
 

--- a/lib/utils/manifest.js
+++ b/lib/utils/manifest.js
@@ -154,8 +154,6 @@ export const createManifest = async (runner, config) => {
 
       if (key === 'HOOKS' && typeof value !== 'object')
         throw new Error(`HOOKS export for ${path} must be an object`)
-
-      console.log(`type of ${key} is ${typeof value}`)
     })
 
     manifest.routes[dev_endpoint_path] = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xinkjs/xink",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/xinkjs/xink.git"


### PR DESCRIPTION
In order to simplify things, HOOKS is now required to be an object instead of a function that returns an object. There's no reason to create overhead for devs here.

- refactor (breaking): HOOKS route export is now an object (https://github.com/xinkjs/xink/commit/4be79c9b9c6c85c9b3f16ab6b162ef1cf691aa46)