### PR TITLE
feat: use adapters

### DIFF
--- a/.changeset/crazy-breads-find.md
+++ b/.changeset/crazy-breads-find.md
@@ -1,0 +1,5 @@
+---
+"@xinkjs/xink": minor
+---
+
+Migrate to an adapter-based system that does not rely on the filesystem at runtime

--- a/packages/xink/index.js
+++ b/packages/xink/index.js
@@ -19,9 +19,9 @@ let entrypoint_path
 
 /**
  * @param {Config} [xink_config]
- * @returns {Promise<import('vite').Plugin>}
+ * @returns {import('vite').Plugin}
  */
-export async function xink(xink_config = {}) {
+export function xink(xink_config = {}) {
   const cwd = process.cwd()
 
   const validated_config = validateConfig(xink_config)

--- a/packages/xink/types.d.ts
+++ b/packages/xink/types.d.ts
@@ -71,10 +71,11 @@ export interface XinkAdapter {
   adapt: (context: XinkAdaptContext) => Promise<void> | void;
 }
 export type XinkConfig = {
-  adapter?: (options?: any) => XinkAdapter;
+  adapter: (options?: any) => XinkAdapter;
   check_origin?: boolean;
   entrypoint?: string; 
   out_dir?: string;
+  serve_options?: { [key: string]: any; };
 }
 
 export interface PlatformContext {


### PR DESCRIPTION
This is a major breaking change, consisting of:

- the `runtime` plugin option has been removed.
- you must now install and pass in an `adapter` to the plugin (@xinkjs/adapter-bun, @xinkjs/adapter-cloudflare, @xinkjs/adapter-deno).
- we no longer rely on filesystem access at runtime; therefore, we now support edge runtimes.