### PR TITLE
feat: basic support for JSX

### DIFF
--- a/.changeset/wide-rooms-help.md
+++ b/.changeset/wide-rooms-help.md
@@ -1,0 +1,6 @@
+---
+"@xinkjs/xink": minor
+"xk": patch
+---
+
+Support for basic JSX

--- a/packages/cli/lib/package.ts
+++ b/packages/cli/lib/package.ts
@@ -6,7 +6,7 @@ const bun = `{
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "start": "bun run build/_worker.js"
+    "start": "bun run build/server.js"
   }
 }
 `
@@ -27,7 +27,7 @@ const deno = `{
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "start": "deno run --allow-net --allow-sys --allow-read=build build/_worker.js"
+    "start": "deno run --allow-net --allow-sys --allow-read=build build/server.js"
   },
   "nodeModulesDir": "auto"
 }

--- a/packages/cli/lib/utils.ts
+++ b/packages/cli/lib/utils.ts
@@ -42,7 +42,8 @@ export const createXink = (project_path: string, runtime: string, language: stri
         "../vite.config.js",
         "../vite.config.ts",
         "../src/**/*.js",
-        "../src/**/*.ts"
+        "../src/**/*.ts",
+        "../src/**/*.tsx
     ],
     "exclude": [
         "../node_modules/**"

--- a/packages/xink/README.md
+++ b/packages/xink/README.md
@@ -2,7 +2,7 @@
 
 xink is a directory-based filesystem router for APIs, acting as a Vite plugin. Under the hood, it uses a trie URL router, which is fast and scalable. It supports the bun, cloudflare, and deno runtimes.
 
-We're currently in the alpha phase of development and welcome contributions. Please see our contributing guide.
+We're currently in the beta phase of development and welcome contributions. Please see our contributing guide.
 
 ## Why use xink?
 
@@ -45,11 +45,7 @@ const api = new Xink()
 
 api.path('/api')
 
-export default {
-  fetch(req: Request) {
-    return api.fetch(req)
-  }
-}
+export default api
 ```
 
 ## Create Routes
@@ -390,6 +386,49 @@ export const handleError = (e: any) => {
     data: null, 
     error: e.message 
   })
+}
+```
+
+## JSX and fallback handling
+
+Basic JSX is supported, as well as directly returning text, numbers, and json.
+
+### JSX
+
+Ensure the following is in your `tsconfig.json` file:
+```json
+"extends": "./.xink/tsconfig.json",
+"compilerOptions": {
+  "jsx": "react-jsx",
+  "jsxImportSource": "@xinkjs/xink"
+}
+```
+
+Returns a text/html response.
+```js
+export const GET = () => {
+  return (
+    <h1>Hello from JSX!</h1>
+  )
+}
+```
+
+### Text and Numbers
+Returns a text/plain response. Numbers are converted to strings.
+```js
+export const GET = () => 'Ok'
+```
+```js
+export const GET = () => 42
+```
+
+### JSON
+Returns an application/json response.
+```js
+export const GET = () => {
+  return {
+    "message": "hello"
+  }
 }
 ```
 

--- a/packages/xink/index.js
+++ b/packages/xink/index.js
@@ -66,7 +66,8 @@ export function xink(xink_config = {}) {
     "../vite.config.js",
     "../vite.config.ts",
     "../src/**/*.js",
-    "../src/**/*.ts"
+    "../src/**/*.ts",
+    "../src/**/*.tsx"
   ],
   "exclude": [
     "../node_modules/**"
@@ -150,7 +151,7 @@ export function xink(xink_config = {}) {
 
       if (isBuild) {
         const routes_glob = new Glob(
-          join(cwd, routes_dir, '**/route.{js,ts}'),
+          join(cwd, routes_dir, '**/route.{js,ts,tsx}'),
           {},
         )
         const params_glob = new Glob(

--- a/packages/xink/lib/runtime/jsx.js
+++ b/packages/xink/lib/runtime/jsx.js
@@ -1,0 +1,173 @@
+// Simple identifier for our VNode objects
+const VNODE_TYPE = Symbol.for('xink.jsx.vnode')
+
+/**
+ * Represents a virtual node created by JSX.
+ */
+class XinkVNode {
+  type = VNODE_TYPE
+  tag
+  props
+  key
+
+  constructor(tag, props, key) {
+    this.tag = tag
+    this.props = props
+    this.key = key
+  }
+}
+
+// --- JSX Runtime Exports ---
+export const Fragment = Symbol.for('xink.jsx.fragment')
+
+/**
+ * JSX transformer function (for single elements/components).
+ * 
+ * @param {string | symbol} tag HTML tag name or Fragment
+ * @param {object} props Props object (children are under props.children)
+ * @param {string | undefined} key Optional key
+ * @returns {XinkVNode}
+ */
+export function jsx(tag, props, key) {
+  return new XinkVNode(tag, props, key)
+}
+
+/**
+ * JSX development transformer function.
+ * In dev mode, Vite/compilers call this. It receives extra args for debugging.
+ * For a minimal runtime, we can just call the regular jsx function.
+ *
+ * @param {string | symbol} tag
+ * @param {object} props
+ * @param {string | undefined} key
+ * @param {boolean} isStaticChildren - Indicates if children are static (for jsxs optimization)
+ * @param {object} sourceDebugInfo - { fileName, lineNumber, columnNumber }
+ * @param {object} thisArg - The 'this' context
+ * @returns {XinkVNode}
+ */
+export function jsxDEV(tag, props, key, isStaticChildren, sourceDebugInfo, thisArg) {
+  // Minimal implementation: Ignore dev-specific args and call the production jsx
+  // You could add console.warn or checks using sourceDebugInfo here if desired
+  return jsx(tag, props, key)
+}
+
+/**
+ * JSX transformer function (optimized for multiple static children).
+ * Same implementation as jsx for this minimal runtime.
+ * 
+ * @param {string | symbol} tag HTML tag name or Fragment
+ * @param {object} props Props object (children are under props.children)
+ * @param {string | undefined} key Optional key
+ * @returns {XinkVNode}
+ */
+export function jsxs(tag, props, key) {
+    // In a more complex runtime, jsxs might optimize children array creation.
+    // For basic rendering, it can be the same as jsx.
+    return new XinkVNode(tag, props, key)
+}
+
+/* Helper to check if something is one of our VNodes. */
+export function isVNode(value) {
+  return value instanceof XinkVNode || (typeof value === 'object' && value !== null && value.type === VNODE_TYPE)
+}
+
+/* Basic HTML escaping. */
+const escape_map = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+}
+const escape_regex = /[&<>"']/g
+
+function escapeHtml(str) {
+  return String(str).replace(escape_regex, (char) => escape_map[char])
+}
+
+const VOID_ELEMENTS = new Set([
+    'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
+    'link', 'meta', 'param', 'source', 'track', 'wbr',
+])
+
+/**
+ * Renders a VNode or other value to an HTML string.
+ * 
+ * @param {any} node The node/value to render.
+ * @returns {string} The rendered HTML string.
+ */
+export function renderToString(node) {
+  if (node === null || node === undefined || typeof node === 'boolean')
+    return ''
+
+  if (typeof node === 'string' || typeof node === 'number')
+    return escapeHtml(node)
+
+  if (Array.isArray(node)) {
+    // Render each item in the array recursively
+    return node.map(child => renderToString(child)).join('')
+  }
+
+  // Check if it's our VNode structure
+  if (isVNode(node)) {
+    const { tag, props } = node
+
+    // Handle Fragment: just render children
+    if (tag === Fragment)
+      return renderToString(props.children)
+
+    // Handle HTML elements (tag is a string)
+    if (typeof tag === 'string') {
+      let html = `<${tag}`
+      let children_html = ''
+
+      // Process props (attributes and children)
+      for (const prop_name in props) {
+        if (prop_name === 'children') {
+          children_html = renderToString(props.children)
+          continue
+        }
+
+        // Skip event handlers (like onClick) on the server
+        if (prop_name.startsWith('on') && typeof props[prop_name] === 'function')
+          continue
+
+        const value = props[prop_name]
+
+        // Handle boolean attributes (e.g., disabled, checked)
+        if (typeof value === 'boolean') {
+          if (value) html += ` ${prop_name}` // Add attribute name if true
+          // Skip attribute if false
+        }
+        // Handle other attributes
+        else if (value !== null && value !== undefined) {
+          // Basic handling for style objects (convert to string)
+          if (prop_name === 'style' && typeof value === 'object') {
+            const style_string = Object.entries(value)
+              .map(([k, v]) => `${k.replace(/([A-Z])/g, '-$1').toLowerCase()}:${v}`)
+              .join(';')
+            html += ` ${prop_name}="${escapeHtml(style_string)}"`
+          } else {
+            html += ` ${prop_name}="${escapeHtml(String(value))}"`
+          }
+        }
+      }
+
+      // Check for void elements
+      if (VOID_ELEMENTS.has(tag.toLowerCase())) {
+        html += '/>' // Self-close void elements
+        // Void elements cannot have children, ignore children_html
+        return html
+      } else {
+        html += '>' // Close opening tag
+        html += children_html // Add children
+        html += `</${tag}>` // Add closing tag
+        return html
+      }
+    }
+  }
+
+  // If we don't know how to render it, return empty string
+  console.warn('Cannot render unknown node type:', node)
+  return ''
+}

--- a/packages/xink/lib/utils/main.js
+++ b/packages/xink/lib/utils/main.js
@@ -34,7 +34,7 @@ export const mergeObjects = (current, updates) => {
  * @returns {Generator<string>}
  */
 export function* readFiles(dir, options) {
-  const glob = options?.exact ? new Glob(`${dir}/${options?.filename}.{js,ts}`, {}) : new Glob(`${dir}/**/${options?.filename ?? '*'}.{js,ts}`, {})
+  const glob = options?.exact ? new Glob(`${dir}/${options?.filename}.{js,ts,tsx}`, {}) : new Glob(`${dir}/**/${options?.filename ?? '*'}.{js,tsx}`, {})
 
   for (const file of glob) {
     yield file

--- a/packages/xink/lib/utils/manifest.js
+++ b/packages/xink/lib/utils/manifest.js
@@ -71,7 +71,7 @@ export const createManifestVirtualModule = async (config) => {
   for (let p of readFiles(routes_dir, { filename: 'route' })) {
     const relativePath = p.substring(routes_dir.length)
     const parts = relativePath.split('/')
-    const dirs = parts.filter(t => !((/^route\.(?:js|ts)$/).test(t) || t === ''))
+    const dirs = parts.filter(t => !((/^route\.(?:js|ts|tsx)$/).test(t) || t === ''))
     let urlPath = dirs.length === 0 ? '/' : `/${dirs.join('/')}`
 
     // --- Convert path segments (same logic as original) ---

--- a/packages/xink/package.json
+++ b/packages/xink/package.json
@@ -8,6 +8,14 @@
     ".": {
       "import": "./lib/exports/index.js",
       "types": "./types.d.ts"
+    },
+    "./jsx-runtime": {
+      "import": "./lib/runtime/jsx.js",
+      "types": "./types.d.ts"
+    },
+    "./jsx-dev-runtime": {
+      "import": "./lib/runtime/jsx.js",
+      "types": "./types.d.ts"
     }
   },
   "scripts": {

--- a/packages/xink/types.d.ts
+++ b/packages/xink/types.d.ts
@@ -185,3 +185,74 @@ export declare namespace StandardSchemaV1 {
       Schema['~standard']['types']
   >['output'];
 }
+
+class XinkVNode {
+  type;
+  tag;
+  props;
+  key;
+
+  constructor(tag, props, key)
+}
+
+// Make the JSX namespace available globally for TSX files
+declare global {
+  namespace JSX {
+      /**
+       * Represents a JSX element structure.
+       * Corresponds to the return type of the jsx/jsxs functions.
+       */
+      type Element = XinkVNode;
+
+      /**
+       * Defines the allowed properties for intrinsic HTML elements.
+       * Using Record<string, any> is the bare minimum.
+       * A full implementation would list all standard HTML tags and their specific attributes.
+       * See libraries like [at]types/react for comprehensive examples.
+       */
+      interface IntrinsicElements {
+          // Allow any standard HTML tag with any properties
+          [elem_mame: string]: Record<string, any>;
+
+          // Example of specific typing (better DX):
+          // div: { id?: string; class?: string; children?: any; style?: Record<string, string>; onClick?: Function };
+          // a: { href?: string; target?: string; children?: any; };
+          // img: { src?: string; alt?: string; width?: number; height?: number; };
+      }
+
+      // You might need to define ElementAttributesProperty and ElementChildrenAttribute
+      // if your runtime handles props differently, but defaults often work.
+      // interface ElementAttributesProperty { props: {}; }
+      // interface ElementChildrenAttribute { children: {}; }
+  }
+}
+
+// Define the type for props, including children
+type JsxProps = Record<string, any> & { children?: any };
+
+export const Fragment: unique symbol;
+
+export function jsx(
+  tag: string | symbol | Function,
+  props: JsxProps,
+  key?: string | number | undefined
+): XinkVNode;
+
+export function jsxDEV(
+  tag: string | symbol | Function,
+  props: JsxProps,
+  key?: string | number | undefined,
+  isStaticChildren?: boolean,
+  sourceDebugInfo?: {
+    fileName?: string;
+    lineNumber?: number;
+    columnNumber?: number;
+  },
+  thisArg?: any
+): XinkVNode;
+
+export function jsxs(
+  tag: string | symbol | Function,
+  props: JsxProps,
+  key?: string | number | undefined
+): XinkVNode;


### PR DESCRIPTION
You can now return basic JSX in route handlers. Please checkout the README for details on what to add to your tsconfig.json file.

It also adds fallback support for returning text, numbers, and JSON from your route handlers. As well as a small fix for the cli tool.