### PR TITLE
fix: broken routing for ts files

### DIFF
--- a/.changeset/eleven-ideas-brush.md
+++ b/.changeset/eleven-ideas-brush.md
@@ -1,0 +1,5 @@
+---
+"@xinkjs/xink": patch
+---
+
+Fix broken routing for ts files

--- a/packages/xink/lib/utils/main.js
+++ b/packages/xink/lib/utils/main.js
@@ -34,7 +34,7 @@ export const mergeObjects = (current, updates) => {
  * @returns {Generator<string>}
  */
 export function* readFiles(dir, options) {
-  const glob = options?.exact ? new Glob(`${dir}/${options?.filename}.{js,ts,tsx}`, {}) : new Glob(`${dir}/**/${options?.filename ?? '*'}.{js,tsx}`, {})
+  const glob = options?.exact ? new Glob(`${dir}/${options?.filename}.{js,ts,tsx}`, {}) : new Glob(`${dir}/**/${options?.filename ?? '*'}.{js,ts,tsx}`, {})
 
   for (const file of glob) {
     yield file


### PR DESCRIPTION
During the implementation of JSX handling, routing for ts files was broken.