### PR TITLE
fix: infer validation types for strings

### DIFF
--- a/.changeset/hot-results-stand.md
+++ b/.changeset/hot-results-stand.md
@@ -1,0 +1,5 @@
+---
+"@xinkjs/xink": patch
+---
+
+Infer validation types for strings

--- a/packages/xink/README.md
+++ b/packages/xink/README.md
@@ -237,6 +237,11 @@ export const POST = (event) => {
 
 Validate incoming route data for types `form`, `json`, route `params`, or `query` search params. Validated data is available as an object within `event.valid`. You can validate using either validator functions or schemas.
 
+Any "string" values within `form`, `params`, and `query`, are automatically inferred to their intended type. For example:
+- "42" -> 42 (number)
+- "false" -> false (boolean)
+- "null" -> null (null)
+
 Any thrown errors can be handled by `handleError()` (see further below).
 
 ### Using Validators

--- a/packages/xink/lib/runtime/fetch.js
+++ b/packages/xink/lib/runtime/fetch.js
@@ -2,7 +2,7 @@
 /** @import { CookieParseOptions, CookieSerializeOptions } from 'cookie' */
 
 import { parse, serialize } from 'cookie'
-import { isContentType } from './utils.js'
+import { inferObjectValueTypes, isContentType } from './utils.js'
 import { DISALLOWED_METHODS } from '../constants.js'
 import { StandardSchemaError, json, text, html } from './helpers.js'
 import { isVNode, renderToString } from "./jsx.js"
@@ -340,12 +340,18 @@ export const resolve = async (event) => {
           form_values[p[0]] = p[1]
         }
 
-        event.valid.form = using_schema ? await standardValidator(validator, form_values) : validator(form_values)
+        /* Apply type inference. */
+        const inferred_form_data = inferObjectValueTypes(form_values)
+
+        event.valid.form = using_schema ? await standardValidator(validator, inferred_form_data) : validator(inferred_form_data)
         continue
       }
 
       if (validator_type === 'params') {
-        event.valid.params = using_schema ? await standardValidator(validator, event.params) : validator(event.params)
+        /* Apply type inference. */
+        const inferred_params = inferObjectValueTypes(event.params)
+
+        event.valid.params = using_schema ? await standardValidator(validator, inferred_params) : validator(inferred_params)
         continue
       }
       
@@ -357,7 +363,10 @@ export const resolve = async (event) => {
           query_obj[key] = value
         }
 
-        event.valid.query = using_schema ? await standardValidator(validator, query_obj) : validator(query_obj)
+        /* Apply type inference. */
+        const inferred_search_params = inferObjectValueTypes(query_obj)
+
+        event.valid.query = using_schema ? await standardValidator(validator, inferred_search_params) : validator(inferred_search_params)
         continue
       }
     }

--- a/packages/xink/lib/runtime/utils.js
+++ b/packages/xink/lib/runtime/utils.js
@@ -9,3 +9,53 @@ export const isContentType = (request, ...types) => {
   const type = request.headers.get('content-type')?.split(';', 1)[0].trim() ?? ''
 	return types.includes(type.toLowerCase())
 }
+
+/**
+ * Attempts to infer richer types (boolean, number, null)
+ * from query param strings. Keeps original strings if no other type matches.
+ * @param {Record<string, string | File | any>} input_obj Object with potentially mixed value types.
+ * @returns {Record<string, string | number | boolean | null | File | any>} Object with inferred types for strings.
+ */
+export function inferObjectValueTypes(input_obj) {
+  const inferred_obj = {}
+  for (const key in input_obj) {
+    const value = input_obj[key]
+
+    if (typeof value === 'string') {
+      if (value.toLowerCase() === 'null') {
+        inferred_obj[key] = null
+      } 
+      else if (value.toLowerCase() === 'true') {
+        inferred_obj[key] = true
+      } 
+      else if (value.toLowerCase() === 'false') {
+        inferred_obj[key] = false
+      }
+      /**
+       * Check for numbers (handle integers and floats).
+       * Use Number() for broader parsing but check if it's NaN.
+       * Also check if the string representation matches the original value
+       * to avoid partial parses like Number("123xyz") -> 123
+       */
+      else if (value.trim() !== '' && !isNaN(Number(value))) {
+        /* Check if converting back to string matches original (handles cases like "1.2.3"). */
+        const num_val = Number(value)
+        if (String(num_val) === value) {
+          inferred_obj[key] = num_val
+        } else {
+          /* If string representation doesn't match, keep original string. */
+          inferred_obj[key] = value
+        }
+      }
+      /* Keep as string if no other type matches. */
+      else {
+        inferred_obj[key] = value
+      }
+    }
+    else {
+      /* If not a string (e.g., File object), keep the original value. */
+      inferred_obj[key] = value
+    }
+  }
+  return inferred_obj
+}


### PR DESCRIPTION
For form data, search params, and route params, we now infer the "intended" type for strings.

e.g.
- "42" -> 42
- "false" -> false