### PR TITLE
breaking: SCHEMAS and VALIDATORS methods must be lowercase

### DIFF
--- a/.changeset/spicy-hornets-glow.md
+++ b/.changeset/spicy-hornets-glow.md
@@ -1,0 +1,5 @@
+---
+"@xinkjs/xink": minor
+---
+
+SCHEMAS and VALIDATORS methods must be lowercase

--- a/packages/xink/README.md
+++ b/packages/xink/README.md
@@ -255,7 +255,7 @@ In the Zod example below, only json data which matches your schema, will be avai
 import { z } from 'zod'
 
 const VALIDATORS = {
-  POST: {
+  post: {
     json: (z.object({
       hello: z.string(),
       goodbye: z.number()
@@ -303,7 +303,7 @@ type PostTypes = {
 }
 
 const VALIDATORS: Validators = {
-  POST: {
+  post: {
     json: v.parser(post_json_schema)
   }
 }
@@ -331,7 +331,7 @@ export const POST = async (event: RequestEvent<PostTypes>) => {
 import * as v from 'valibot'
 
 const SCHEMAS = {
-  POST: {
+  post: {
     json: v.object({
       hello: v.string(),
       goodbye: v.number()
@@ -430,7 +430,7 @@ const post_res_schema = v.object({
 /* Define SCHEMAS within the HOOKS export. */
 export const HOOKS = {
   SCHEMAS: {
-    POST: {
+    post: {
       json: toJsonSchema(post_json_schema)
     }
   }
@@ -818,14 +818,25 @@ interface RequestEvent<V extends AllowedValidatorTypes = AllowedValidatorTypes> 
   valid: V
 }
 
+export interface Schemas {
+  get?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  post?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  put?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  patch?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  delete?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  head?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  options?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  default?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+}
+
 interface Validators {
-  GET?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
-  POST?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
-  PUT?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
-  PATCH?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
-  DELETE?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
-  HEAD?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
-  OPTIONS?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  get?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  post?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  put?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  patch?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  delete?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  head?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  options?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
   default?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
 }
 ```

--- a/packages/xink/lib/runtime/fetch.js
+++ b/packages/xink/lib/runtime/fetch.js
@@ -373,14 +373,15 @@ export const resolve = async (event) => {
   }
 
   const hooks = event.store.HOOKS ?? null
+  const method = event.request.method.toLowerCase()
 
   if (hooks) {
-    if (hooks.VALIDATORS?.[event.request.method]) {
-      const validators = Object.entries(hooks.VALIDATORS[event.request.method])
+    if (hooks.VALIDATORS?.[method]) {
+      const validators = Object.entries(hooks.VALIDATORS[method])
       await validation(validators)
-    } else if (hooks?.SCHEMAS?.[event.request.method]) {
+    } else if (hooks?.SCHEMAS?.[method]) {
       using_schema = true
-      const schemas = Object.entries(hooks.SCHEMAS[event.request.method])
+      const schemas = Object.entries(hooks.SCHEMAS[method])
       await validation(schemas)
     }
 

--- a/packages/xink/lib/runtime/openapi.js
+++ b/packages/xink/lib/runtime/openapi.js
@@ -66,15 +66,14 @@ export const generateOpenapiForRouteMethods = (schemas_export, openapi_export) =
   const methods_to_process = new Set()
 
   if (schemas_export)
-    Object.keys(schemas_export).forEach(method => methods_to_process.add(method.toUpperCase()))
+    Object.keys(schemas_export).forEach(method => methods_to_process.add(method))
 
   if (openapi_export)
-    Object.keys(openapi_export).forEach(method => methods_to_process.add(method.toUpperCase()))
+    Object.keys(openapi_export).forEach(method => methods_to_process.add(method))
 
-  for (const http_method_upper of methods_to_process) {
-    const http_method_lower = http_method_upper.toLowerCase()
-    const method_schemas = schemas_export?.[http_method_upper] || {}
-    const manual_method_openapi = openapi_export?.[http_method_lower] || {} // OpenAPI usually uses lowercase methods
+  for (const method of methods_to_process) {
+    const method_schemas = schemas_export?.[method] || {}
+    const manual_method_openapi = openapi_export?.[method] || {}
 
     const inferred_operation = {}
 
@@ -176,7 +175,7 @@ export const generateOpenapiForRouteMethods = (schemas_export, openapi_export) =
 
 
     if (Object.keys(final_operation).length > 0)
-      openapi_by_method[http_method_lower] = final_operation
+      openapi_by_method[method] = final_operation
   }
 
   return openapi_by_method

--- a/packages/xink/types.d.ts
+++ b/packages/xink/types.d.ts
@@ -47,14 +47,24 @@ export interface RequestEvent<V extends AllowedValidatorTypes = AllowedValidator
 }
 export type ResolveEvent = (event: RequestEvent) => MaybePromise<Response>;
 
+export interface Schemas {
+  get?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  post?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  put?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  patch?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  delete?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  head?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  options?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  default?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+}
 export interface Validators {
-  GET?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
-  POST?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
-  PUT?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
-  PATCH?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
-  DELETE?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
-  HEAD?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
-  OPTIONS?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  get?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  post?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  put?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  patch?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  delete?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  head?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
+  options?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
   default?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;
 }
 export interface XinkAdaptContext {


### PR DESCRIPTION
In order to simplify syntax, http method properties within the SCHEMAS and VALIDATORS export objects must now be lowercase.

Instead of burdening developers with having to know that some object properties must be uppercase and the same within the OPENAPI export must be lowercase, we are standardizing on lowercase.

The endpoint's handlers (that are `export`ed) will remain uppercase (e.g GET, POST, HOOKS, OPENAPI).