### PR TITLE
refactor: hooks processing

### DIFF
--- a/.changeset/silly-hairs-try.md
+++ b/.changeset/silly-hairs-try.md
@@ -1,0 +1,5 @@
+---
+"@xinkjs/xink": patch
+---
+
+refactor, clarify hook processing

--- a/packages/xink/README.md
+++ b/packages/xink/README.md
@@ -193,30 +193,19 @@ You can define hooks for each route, with the `HOOKS` export. They are run for a
 
 - Have access to `Request`.
 - Do not have access to `Response`.
-- Must return either `null` or `event`. If `event` is changed, it needs to be returned in order to access the updated version in handlers.
 - Functions can be sync or async.
-- Are not guaranteed to run in any particular order.
+- Highly likely to run in top-down order, as we use `Object.entries()` to process them.
 
 ```ts
 /* src/routes/route.ts */
 import logger from 'pino'
 
 export const HOOKS = {
-  state: (event: RequestEvent) => {
-    event.locals.state = { some: 'thing' }
-
-    return event
-  },
-  log: () => {
-    logger().info('Hello from Pino!')
-
-    return null
-  },
+  state: (event: RequestEvent) => event.locals.state = { some: 'thing' },
+  log: () => logger().info('Hello from Pino!'),
   poki: async (event: RequestEvent) => {
     const res = await fetch('https://pokeapi.co/api/v2/pokemon/pikachu')
     event.locals.poki = await res.json()
-
-    return event
   }
 }
 
@@ -265,7 +254,7 @@ const VALIDATORS = {
 
 export const HOOKS = {
   VALIDATORS,
-  someOtherHook: () => null
+  someOtherHook: () => console.log('the right stuff')
 }
 
 /**
@@ -341,7 +330,7 @@ const SCHEMAS = {
 
 export const HOOKS = {
   SCHEMAS,
-  someOtherHook: () => null
+  someOtherHook: () => console.log('the right stuff')
 }
 
 /**

--- a/packages/xink/lib/constants.js
+++ b/packages/xink/lib/constants.js
@@ -21,4 +21,8 @@ export const DISALLOWED_METHODS = new Set([
   'default', 'HOOKS', 'OPENAPI'
 ])
 
+export const SPECIAL_HOOKS = new Set([
+  'SCHEMAS', 'VALIDATORS'
+])
+
 export const MAX_COOKIE_SIZE = 4129


### PR DESCRIPTION
Refactor hook processing for readability. Also clarifies that you don't need to return `null` or any changed `event` from your hook functions. Silly me did not understand this until now. No `return`s needed!