### PR TITLE
fix: remove lib alias, xk outputs

### DIFF
--- a/.changeset/plain-cobras-fold.md
+++ b/.changeset/plain-cobras-fold.md
@@ -1,0 +1,6 @@
+---
+"@xinkjs/xink": patch
+"xk": patch
+---
+
+Remove alias config and fix outputs

--- a/packages/cli/lib/package.ts
+++ b/packages/cli/lib/package.ts
@@ -29,7 +29,29 @@ const deno = `{
     "preview": "vite preview",
     "start": "deno run --allow-net --allow-sys --allow-read=build build/server.js"
   },
-  "nodeModulesDir": "auto"
+  "nodeModulesDir": "auto",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "esnext",
+    "verbatimModuleSyntax": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "@xinkjs/xink"
+  },
+  "exclude": [
+    "node_modules/",
+    "build/"
+  ]
 }
 `
 

--- a/packages/cli/lib/utils.ts
+++ b/packages/cli/lib/utils.ts
@@ -11,56 +11,39 @@ export const createXink = (project_path: string, runtime: string, language: stri
     /* Create project path. */
     mkdirSync(project_path, { recursive: true })
 
-    if (language !== 'none') {
-        /* Create xink type-checking file. */
-        mkdirSync(join(project_path, '.xink'), { recursive: true })
-        writeFileSync(join(project_path, `.xink/tsconfig.json`),
-            `{
-    "compilerOptions": {
-        "paths": {
-            "$lib": [
-                "../src/lib"
-            ],
-            "$lib/*": [
-                "../src/lib/*"
-            ]
-        },
-        "verbatimModuleSyntax": true,
-        "isolatedModules": true,
-        "moduleResolution": "bundler",
-        "module": "esnext",
-        "noEmit": true,
-        "target": "esnext"
-    },
-    "include": [
-        "../vite.config.js",
-        "../vite.config.ts",
-        "../src/**/*.js",
-        "../src/**/*.ts",
-        "../src/**/*.tsx"
-    ],
-    "exclude": [
-        "../node_modules/**"
-    ]
-}
-`
-        )
-
-        /* Create project type-checking file. */
+    if (language === 'bun' || language === 'cloudflare') {
+        /* Create project type-checking file. Deno is handled in package.ts */
         writeFileSync(join(project_path, `${type}config.json`),
             `{
-    "extends": "./.xink/${type}config.json",
     "compilerOptions": {
         "allowJs": true,
         "checkJs": true,
         "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true,
+        "isolatedModules": true,
+        "moduleResolution": "bundler",
+        "module": "esnext",
+        "noEmit": true,
         "resolveJsonModule": true,
         "skipLibCheck": true,
         "sourceMap": true,
         "strict": true,
-        "moduleResolution": "bundler"
-    }
+        "target": "esnext",
+        "verbatimModuleSyntax": true,
+        "jsx": "react-jsx",
+        "jsxImportSource": "@xinkjs/xink"
+    },
+    "include": [
+        "vite.config.js",
+        "vite.config.ts",
+        "src/**/*.js",
+        "src/**/*.ts",
+        "src/**/*.tsx"
+    ],
+    "exclude": [
+        "node_modules",
+        "build"
+    ]
 }
 `
         )
@@ -82,7 +65,7 @@ export default api
 import { defineConfig } from 'vite'
 import adapter from '@xinkjs/adapter-${runtime}'
 
-export default defineConfig(async function () {
+export default defineConfig(function () {
     return {
         plugins: [
             xink({ 

--- a/packages/xink/index.js
+++ b/packages/xink/index.js
@@ -3,7 +3,6 @@
 import { validateConfig } from './lib/utils/config.js'
 import { getRequest, setResponse } from './lib/utils/vite.js'
 import { createManifestVirtualModule } from './lib/utils/manifest.js'
-import { statSync, mkdirSync, writeFileSync } from 'node:fs'
 import { join, relative } from 'node:path'
 import { Glob } from 'glob'
 
@@ -34,47 +33,6 @@ export function xink(xink_config = {}) {
 
   let virtual_manifest_content = ''
   let is_build = false
-
-  let tsconfig_file_exists = false
-  const tsconfig_path = join(cwd, '.xink/tsconfig.json')
-  try {
-    statSync(tsconfig_path).isFile()
-    tsconfig_file_exists = true
-  } catch (error) {}
-  
-  if (!tsconfig_file_exists) {
-    mkdirSync(join(cwd, '.xink'), { recursive: true })
-    writeFileSync(join(cwd, '.xink/tsconfig.json'),
-      `{
-  "compilerOptions": {
-    "paths": {
-      "$lib": [
-        "../src/lib"
-      ],
-      "$lib/*": [
-        "../src/lib/*"
-      ]
-    },
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "moduleResolution": "bundler",
-    "module": "esnext",
-    "noEmit": true,
-    "target": "esnext"
-  },
-  "include": [
-    "../vite.config.js",
-    "../vite.config.ts",
-    "../src/**/*.js",
-    "../src/**/*.ts",
-    "../src/**/*.tsx"
-  ],
-  "exclude": [
-    "../node_modules/**"
-  ]
-}`
-    )
-  }
 
   return {
     name: 'vite-plugin-xink',
@@ -211,12 +169,7 @@ export function xink(xink_config = {}) {
         define: {
           XINK_CHECK_ORIGIN: validated_config.check_origin,
         },
-        ssr: { noExternal: ['@xinkjs/xink'] },
-        resolve: {
-          alias: {
-            $lib: join(cwd, 'src/lib'),
-          },
-        },
+        ssr: { noExternal: ['@xinkjs/xink'] }
       }
     },
     async configureServer(server) {


### PR DESCRIPTION
- removes built-in support for `$lib` import alias
- uses proper files for Deno, and other outputs for xk