### PR TITLE
feat: support OpenAPI reference requests

### DIFF
--- a/.changeset/gold-hats-push.md
+++ b/.changeset/gold-hats-push.md
@@ -1,0 +1,5 @@
+---
+"@xinkjs/xink": minor
+---
+
+Support requesting OpenAPI schema for code generators


### PR DESCRIPTION
Allows you to use client generator tools, like Hey API, to create typed API clients for your Xink APIs, based on OpenAPI definitions.

This requires you to setup OpenAPI for your routes (see docs). Then, you can get the schema needed from a new endpoint, based on your defined OpenAPI path.

e.g. the below entrypoint file would allow a request to `/reference/schema` to return your OpenAPI schema as json, to be used in your code generator tool.
```js
/* index.ts */
import { Xink } from "@xinkjs/xink"

const api = new Xink()

api.openapi({
  path: '/reference'
})

export default api
```