### PR TITLE
docs: api client support

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -28,6 +28,7 @@ export default defineConfig({
 						{ label: 'Hooks', slug: 'docs/hooks' },
 						{ label: 'Errors', slug: 'docs/errors' },
 						{ label: 'OpenAPI', slug: 'docs/openapi' },
+						{ label: 'API Client', slug: 'docs/client'},
 						{ label: 'JSX', slug: 'docs/jsx' },
 						{ label: 'Return Types', slug: 'docs/return-types' },
 						{ label: 'Helpers', slug: 'docs/helpers' },

--- a/docs/src/content/docs/docs/client.md
+++ b/docs/src/content/docs/docs/client.md
@@ -1,0 +1,19 @@
+---
+title: API Client
+---
+
+xink doesn't have a typed API client, but you can use our OpenAPI integration to create one with a generator like [Hey API](https://heyapi.dev/openapi-ts/get-started).
+
+1. Setup your OpenAPI definitions and path.
+2. Generate a client using the schema xink provides at `/<openapi-path>/schema`.
+
+For example, if you're using Hey API, you can run the command below to create your client.
+
+> We're assuming `/reference` as your OpenAPI path; and you'll need to install `@hey-api/client-fetch` in your app before you can make API requests.
+
+```bash
+npx @hey-api/openapi-ts \
+  -i https://example.com/reference/schema \
+  -o src/client \
+  -c @hey-api/client-fetch
+```

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -31,7 +31,7 @@ import { Card, CardGrid, LinkButton } from '@astrojs/starlight/components';
 
 <CardGrid stagger>
   <Card title="It's a Vite Plugin" icon="seti:vite">
-		Powered by the best and the brightest.
+		Need we say more?
 	</Card>
   <Card title="Directory-based Routing" icon="seti:folder">
 		Organized, standardized, and ready to go.
@@ -44,6 +44,9 @@ import { Card, CardGrid, LinkButton } from '@astrojs/starlight/components';
 	</Card>
 	<Card title="Automatic OpenAPI Docs" icon="document">
 		From your Standard Schema, and more.
+	</Card>
+  <Card title="API client support" icon="seti:typescript">
+		Schema endpoint to create a typed client using generators like Hey API.
 	</Card>
   <Card title="Setup is a one-liner" icon="forward-slash">
 		npx xk create myapi


### PR DESCRIPTION
Add documentation for the new OpenAPI `/schema` endpoint.