### PR TITLE
fix: openapi method types

### DIFF
--- a/.changeset/major-kids-cry.md
+++ b/.changeset/major-kids-cry.md
@@ -1,0 +1,5 @@
+---
+"@xinkjs/xink": patch
+---
+
+fix openapi method types

--- a/packages/xink/types.d.ts
+++ b/packages/xink/types.d.ts
@@ -117,10 +117,10 @@ export class Xink extends Router {
   openapi(metadata: { 
     path: string; 
     data?: {
-      "openapi": string;
-      "info": {
-        "title": string;
-        "version": string;
+      openapi?: string;
+      info?: {
+        title?: string;
+        version?: string;
       }
     }
   }): void;


### PR DESCRIPTION
Makes them all optional, and also stops using keys as strings.