### PR TITLE
fix: deno dependencies

### DIFF
--- a/.changeset/lemon-sides-wash.md
+++ b/.changeset/lemon-sides-wash.md
@@ -1,0 +1,6 @@
+---
+"@xinkjs/xink": patch
+"xk": patch
+---
+
+Fix deno build. Update to vite v7

--- a/packages/cli/commands/create.ts
+++ b/packages/cli/commands/create.ts
@@ -108,7 +108,7 @@ export const create = new Command('create')
         const steps = [
             'Next Steps:',
             `  cd ${project_path.split('/').at(-1)}`,
-            `  ${runtime === 'bun' ? 'bun add -D vite @xinkjs/xink @xinkjs/adapter-bun' : runtime === 'deno' ? 'deno add -D npm:vite npm:@xinkjs/xink npm:@xinkjs/adapter-deno' : 'npm add -D vite @xinkjs/xink @xinkjs/adapter-cloudflare'}`,
+            `  ${runtime === 'bun' ? 'bun add -D vite @xinkjs/xink @xinkjs/adapter-bun' : runtime === 'deno' ? 'deno add -D npm:vite npm:@xinkjs/xink npm:@xinkjs/adapter-deno npm:glob' : 'npm add -D vite @xinkjs/xink @xinkjs/adapter-cloudflare'}`,
             `  ${runtime === 'bun' ? 'bun run dev' : runtime === 'deno' ? 'deno task dev' : 'npm run dev'}`
         ]
         p.log.info(steps.join('\n'))

--- a/packages/cli/lib/package.ts
+++ b/packages/cli/lib/package.ts
@@ -33,17 +33,7 @@ const deno = `{
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "isolatedModules": true,
-    "moduleResolution": "bundler",
-    "module": "esnext",
-    "noEmit": true,
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "sourceMap": true,
     "strict": true,
-    "target": "esnext",
     "verbatimModuleSyntax": true,
     "jsx": "react-jsx",
     "jsxImportSource": "@xinkjs/xink"

--- a/packages/xink/index.js
+++ b/packages/xink/index.js
@@ -144,6 +144,7 @@ export function xink(xink_config = {}) {
           target: 'esnext',
           minify: false,
           rollupOptions: {
+            external: ['glob'],
             input,
             output: {
               // --- (Keep output filename logic) ---

--- a/packages/xink/package.json
+++ b/packages/xink/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@types/bun": "latest",
-    "vite": "^6.2.3",
+    "vite": "^7.0.0",
     "vitest": "^2.1.9"
   },
   "dependencies": {
@@ -33,7 +33,7 @@
     "@xinkjs/xin": "^0.4.1"
   },
   "peerDependencies": {
-    "vite": "^6.0.0"
+    "vite": "^7.0.0"
   },
   "files": [
     "lib",


### PR DESCRIPTION
This is hopefully a temporary fix. Deno is bundling the `glob` package, which we don't want. This fix ensures that vite always externalizes `glob`, and that when using deno, we add `glob` to the deno.json imports.

Ideally, we'd switch to a more compatible library or use node:fs.