### PR TITLE
feat: RouteHandler type

### DIFF
--- a/packages/xink/types.d.ts
+++ b/packages/xink/types.d.ts
@@ -35,12 +35,12 @@ export type ErrorHandler = (error: unknown, event?: RequestEvent) => MaybePromis
 export type Handle = (event: RequestEvent, resolve: ResolveEvent) => MaybePromise<Response>;
 export type MaybePromise<T> = T | Promise<T>;
 export type Middleware = (event: RequestEvent, resolve: ResolveEvent) => MaybePromise<Response>;
-export interface RequestEvent<V extends AllowedValidatorTypes = AllowedValidatorTypes> {
+export interface RequestEvent<ReqT extends AllowedValidatorTypes = AllowedValidatorTypes, ResT = unknown> {
   context: { env: Env.Bindings, ctx: Context } | null,
   cookies: Cookies;
   headers: Omit<Headers, 'toJSON' | 'count' | 'getAll'>;
   html: typeof html;
-  json: typeof json;
+  json: <T extends ResT>(data: T, init?: ResponseInit) => Response;
   locals: Api.Locals;
   params: Params;
   redirect: typeof redirect;
@@ -49,9 +49,10 @@ export interface RequestEvent<V extends AllowedValidatorTypes = AllowedValidator
   setHeaders: (headers: { [key: string]: any; }) => void;
   text: typeof text;
   url: Omit<URL, 'createObjectURL' | 'revokeObjectURL' | 'canParse'>;
-  valid: V;
+  valid: ReqT;
 }
 export type ResolveEvent = (event: RequestEvent) => MaybePromise<Response>;
+export type RouteHandler<ReqT, ResT> = (event: RequestEvent<ReqT, ResT>) => MaybePromise<Response | ResT>;
 
 export interface Schemas {
   get?: AtLeastOne<AllowedValidatorTypes, 'form' | 'json' | 'params' | 'query'>;


### PR DESCRIPTION
You can now pass Request data types and Response data types to a new type, `RouteHandler`. The Response data type is specifically for returning json. The new type negates the need to use `RequestEvent`.

If you're not using Response types, therefore not using the `RouteHandler` type, then you can still pass your Request types, for validation, into `RequestEvent` if you'd like.