### PR TITLE
feat: set openapi tags for all route handlers

### DIFF
--- a/.changeset/fifty-actors-take.md
+++ b/.changeset/fifty-actors-take.md
@@ -1,0 +1,5 @@
+---
+"@xinkjs/xink": minor
+---
+
+Allow route-level openapi tags.


### PR DESCRIPTION
Allows you to set a top-level `tags` property in the `OPENAPI` export of route handlers. These tags are applied to all operations. If any "local" tags exist, the top-level tags will be merged with them.

e.g.
```ts
export const OPENAPI = {
  tags: ['All'],
  get: {
    tags: ['Gets'],
    ...
  },
  post: {
    tags: ['Posts'],
     ...
  }
}
```