### PR TITLE
feat: set custom Not Found response

### DIFF
--- a/.changeset/plenty-banks-talk.md
+++ b/.changeset/plenty-banks-talk.md
@@ -1,0 +1,5 @@
+---
+"@xinkjs/xink": minor
+---
+
+Allow custom Not Found handler

--- a/packages/xink/lib/runtime/fetch.js
+++ b/packages/xink/lib/runtime/fetch.js
@@ -271,7 +271,12 @@ export const resolve = async (event) => {
    * This check needs to stay here, so that any middleware
    * can potentially handle a requested endpoint before returning a 404.
    */
-  if (!event.store) return new Response('Not Found', { status: 404 })
+  if (!event.store) return new Response('Not Found', { 
+    status: 404,
+    headers: {
+      'x-xink-default-404': 'true'
+    } 
+  })
 
   const handler = event.store[event.request.method] ?? event.store['default']
 

--- a/packages/xink/lib/utils/manifest.js
+++ b/packages/xink/lib/utils/manifest.js
@@ -20,6 +20,7 @@ export const createManifestVirtualModule = async (config) => {
   const paramMatcherEntries = {} // Stores { matcherType: '_mod1.match' }
   let middlewareHandlerRef = 'null' // Stores '_mod2.handle' or 'null'
   let errorHandlerRef = 'null' // Stores '_mod3.handleError' or 'null'
+  let notFoundHandlerRef = 'null'
 
   const addImport = (filePath) => {
     // Ensure absolute path for Vite to resolve correctly
@@ -55,8 +56,9 @@ export const createManifestVirtualModule = async (config) => {
   try {
     for (const filePath of readFiles('src', { exact: true, filename: 'error', extensions: ['js', 'ts'] })) {
       const importName = addImport(filePath)
-      // Assume the file exports 'handleError'
+
       errorHandlerRef = `${importName}.handleError`
+      notFoundHandlerRef = `${importName}.handleNotFound`
       break
     }
   } catch (err) { /* ignore if dir doesn't exist */ }
@@ -102,7 +104,8 @@ export const createManifestVirtualModule = async (config) => {
       ${Object.entries(paramMatcherEntries).map(([key, ref]) => `${JSON.stringify(key)}: ${ref}`).join(',\n      ')}
     },
     middleware: ${middlewareHandlerRef},
-    error: ${errorHandlerRef}
+    error: ${errorHandlerRef},
+    notfound: ${notFoundHandlerRef}
   }`
 
   const moduleCode = `

--- a/packages/xink/types.d.ts
+++ b/packages/xink/types.d.ts
@@ -32,6 +32,7 @@ export type Cookies = {
   getAll(options?: ParseOptions): Array<{ name: string, value: string }>;
   set(name: string, value: string, options?: SerializeOptions): void;
 }
+export type NotFoundHandler = (event?: RequestEvent) => MaybePromise<Response | void>;
 export type ErrorHandler = (error: unknown, event?: RequestEvent) => MaybePromise<Response | void>;
 export type Handle = (event: RequestEvent, resolve: ResolveEvent) => MaybePromise<Response>;
 export type MaybePromise<T> = T | Promise<T>;


### PR DESCRIPTION
Allows a developer to set their own Not Found response by exporting a `handleNotFound` function in `src/error.ts`