### PR TITLE
fix: bun environment for dev and preview

### DIFF
--- a/.changeset/small-ads-cross.md
+++ b/.changeset/small-ads-cross.md
@@ -1,0 +1,5 @@
+---
+"xk": patch
+---
+
+bun enviroment for dev and preview

--- a/packages/cli/lib/package.ts
+++ b/packages/cli/lib/package.ts
@@ -3,9 +3,9 @@ const bun = `{
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "bun --bun vite",
     "build": "vite build",
-    "preview": "vite preview",
+    "preview": "bun --bun vite preview",
     "start": "bun run build/server.js"
   }
 }


### PR DESCRIPTION
Allows you to use things like `Bun.env` and other Bun APIs in vite dev and preview servers.