### PR TITLE
refactor: rename JSX node type

### DIFF
--- a/.changeset/fifty-olives-prove.md
+++ b/.changeset/fifty-olives-prove.md
@@ -1,0 +1,6 @@
+---
+"@xinkjs/xink": patch
+"@xinkjs/xin": patch
+---
+
+rename jsx node type

--- a/packages/xin/lib/runtime/jsx.ts
+++ b/packages/xin/lib/runtime/jsx.ts
@@ -12,7 +12,7 @@ export interface JsxProps extends Record<string, any>{
 /**
  * Represents a virtual node created by JSX.
  */
-export class XinVNode {
+export class JSXNode {
   type = VNODE_TYPE
   tag
   props
@@ -31,8 +31,8 @@ export const Fragment = Symbol.for('xin.jsx.fragment')
 /**
  * JSX transformer function (for single elements/components).
  */
-export function jsx(tag: string | symbol | Function, props: JsxProps, key: string | undefined): XinVNode {
-  return new XinVNode(tag, props, key)
+export function jsx(tag: string | symbol | Function, props: JsxProps, key: string | undefined): JSXNode {
+  return new JSXNode(tag, props, key)
 }
 
 /**
@@ -41,7 +41,7 @@ export function jsx(tag: string | symbol | Function, props: JsxProps, key: strin
  * For a minimal runtime, we can just call the regular jsx function.
  *
  */
-export function jsxDEV(tag: string | symbol | Function, props: JsxProps, key: string | undefined, isStaticChildren: boolean, sourceDebugInfo: object, thisArg: object): XinVNode {
+export function jsxDEV(tag: string | symbol | Function, props: JsxProps, key: string | undefined, isStaticChildren: boolean, sourceDebugInfo: object, thisArg: object): JSXNode {
   // Minimal implementation: Ignore dev-specific args and call the production jsx
   // You could add console.warn or checks using sourceDebugInfo here if desired
   return jsx(tag, props, key)
@@ -51,15 +51,15 @@ export function jsxDEV(tag: string | symbol | Function, props: JsxProps, key: st
  * JSX transformer function (optimized for multiple static children).
  * Same implementation as jsx for this minimal runtime.
  */
-export function jsxs(tag: string | symbol | Function, props: JsxProps, key: string | undefined): XinVNode {
+export function jsxs(tag: string | symbol | Function, props: JsxProps, key: string | undefined): JSXNode {
     // In a more complex runtime, jsxs might optimize children array creation.
     // For basic rendering, it can be the same as jsx.
-    return new XinVNode(tag, props, key)
+    return new JSXNode(tag, props, key)
 }
 
 /* Helper to check if something is one of our VNodes. */
-export function isVNode(value: XinVNode | Record<string, any>) {
-  return value instanceof XinVNode || (typeof value === 'object' && value !== null && value.type === VNODE_TYPE)
+export function isVNode(value: JSXNode | Record<string, any>) {
+  return value instanceof JSXNode || (typeof value === 'object' && value !== null && value.type === VNODE_TYPE)
 }
 
 /* Basic HTML escaping. */
@@ -214,7 +214,7 @@ declare global {
      * Represents a JSX element structure.
      * Corresponds to the return type of the jsx/jsxs functions.
      */
-    type Element = XinVNode;
+    type Element = JSXNode;
 
     // TODO: change any to unknown when moving to TS v3
     interface BaseSyntheticEvent<E = object, C = any, T = any> {

--- a/packages/xin/types.ts
+++ b/packages/xin/types.ts
@@ -3,7 +3,7 @@ import type { SerializeOptions, ParseOptions } from 'cookie'
 import type { ApiReferenceConfiguration } from '@scalar/types'
 import type { OpenAPIV3 } from "@scalar/types"
 import type { html, redirect, text } from "./lib/runtime/helpers"
-import type { XinVNode } from "./lib/runtime/jsx.js"
+import type { JSXNode } from "./lib/runtime/jsx.js"
 
 declare global {
   namespace Api {
@@ -52,7 +52,7 @@ export type Handler<
   ReqSchema extends SchemaDefinition = SchemaDefinition,
   ResSchema = unknown,
   Path = unknown, 
-> = (event: RequestEvent<ReqSchema, ResSchema, Path>) => MaybePromise<unknown extends ResSchema ? Response | XinVNode | string | number | Record<string, any> | null | undefined : ResponseT<ResSchema> | ResSchema>;
+> = (event: RequestEvent<ReqSchema, ResSchema, Path>) => MaybePromise<unknown extends ResSchema ? Response | JSXNode | string | number | Record<string, any> | null | undefined : ResponseT<ResSchema> | ResSchema>;
 export type Hook<
   ReqSchema extends SchemaDefinition = SchemaDefinition,
   ResSchema extends unknown = unknown,

--- a/packages/xink/lib/runtime/jsx.d.ts
+++ b/packages/xink/lib/runtime/jsx.d.ts
@@ -1,7 +1,7 @@
 import type { isVNode } from "./jsx.js";
 import type { XinkRenderableChild } from "../../types.js"
 
-export interface XinkVNode {
+export interface JSXNode {
   type: symbol;
   tag: string | symbol | Function;
   props: JsxProps;
@@ -20,7 +20,7 @@ export declare function jsx(
   tag: string | symbol | Function,
   props: JsxProps,
   key?: string | number | undefined
-): XinkVNode;
+): JSXNode;
 
 export declare function jsxDEV(
   tag: string | symbol | Function,
@@ -33,12 +33,12 @@ export declare function jsxDEV(
     columnNumber?: number;
   },
   thisArg?: any
-): XinkVNode;
+): JSXNode;
 
 export declare function jsxs(
   tag: string | symbol | Function,
   props: JsxProps,
   key?: string | number | undefined
-): XinkVNode;
+): JSXNode;
 
-export declare function isVNode(value: any): value is XinkVNode;
+export declare function isVNode(value: any): value is JSXNode;

--- a/packages/xink/lib/runtime/jsx.js
+++ b/packages/xink/lib/runtime/jsx.js
@@ -4,7 +4,7 @@ const VNODE_TYPE = Symbol.for('xink.jsx.vnode')
 /**
  * Represents a virtual node created by JSX.
  */
-class XinkVNode {
+class JSXNode {
   type = VNODE_TYPE
   tag
   props
@@ -26,10 +26,10 @@ export const Fragment = Symbol.for('xink.jsx.fragment')
  * @param {string | symbol | function} tag HTML tag name or Fragment
  * @param {object} props Props object (children are under props.children)
  * @param {string | undefined} key Optional key
- * @returns {XinkVNode}
+ * @returns {JSXNode}
  */
 export function jsx(tag, props, key) {
-  return new XinkVNode(tag, props, key)
+  return new JSXNode(tag, props, key)
 }
 
 /**
@@ -43,7 +43,7 @@ export function jsx(tag, props, key) {
  * @param {boolean} isStaticChildren - Indicates if children are static (for jsxs optimization)
  * @param {object} sourceDebugInfo - { fileName, lineNumber, columnNumber }
  * @param {object} thisArg - The 'this' context
- * @returns {XinkVNode}
+ * @returns {JSXNode}
  */
 export function jsxDEV(tag, props, key, isStaticChildren, sourceDebugInfo, thisArg) {
   // Minimal implementation: Ignore dev-specific args and call the production jsx
@@ -58,17 +58,17 @@ export function jsxDEV(tag, props, key, isStaticChildren, sourceDebugInfo, thisA
  * @param {string | symbol | function} tag HTML tag name or Fragment
  * @param {object} props Props object (children are under props.children)
  * @param {string | undefined} key Optional key
- * @returns {XinkVNode}
+ * @returns {JSXNode}
  */
 export function jsxs(tag, props, key) {
     // In a more complex runtime, jsxs might optimize children array creation.
     // For basic rendering, it can be the same as jsx.
-    return new XinkVNode(tag, props, key)
+    return new JSXNode(tag, props, key)
 }
 
 /* Helper to check if something is one of our VNodes. */
 export function isVNode(value) {
-  return value instanceof XinkVNode || (typeof value === 'object' && value !== null && value.type === VNODE_TYPE)
+  return value instanceof JSXNode || (typeof value === 'object' && value !== null && value.type === VNODE_TYPE)
 }
 
 /* Basic HTML escaping. */

--- a/packages/xink/types.d.ts
+++ b/packages/xink/types.d.ts
@@ -10,7 +10,7 @@ import {
 import type { SerializeOptions, ParseOptions } from 'cookie'
 import type { Plugin } from 'vite'
 import type { Config } from './lib/types/internal'
-import type { XinkVNode, Fragment } from './lib/runtime/jsx'
+import type { JSXNode, Fragment } from './lib/runtime/jsx'
 import * as CSS from 'csstype'
 import type { ApiReferenceConfiguration } from '@scalar/types'
 
@@ -107,7 +107,7 @@ declare global {
      * Represents a JSX element structure.
      * Corresponds to the return type of the jsx/jsxs functions.
      */
-    type Element = XinkVNode;
+    type Element = JSXNode;
 
     // TODO: change any to unknown when moving to TS v3
     interface BaseSyntheticEvent<E = object, C = any, T = any> {


### PR DESCRIPTION
- refactor: rename from `[Xin|Xink]VNode` to `JSXNode`, for better public readability and understanding