### PR TITLE
fix: use extensions for imports

### DIFF
--- a/.changeset/sixty-ties-return.md
+++ b/.changeset/sixty-ties-return.md
@@ -1,0 +1,6 @@
+---
+"@xinkjs/xin": patch
+"@xinkjs/xi": patch
+---
+
+use extensions with imports

--- a/packages/xi/index.ts
+++ b/packages/xi/index.ts
@@ -1,5 +1,13 @@
-import type { MatcherResult, MixedResult, ParsedSegment, XiConfig, Matcher, StoreConstructor, BaseStore } from "./types"
-import { validateConfig } from './lib/config'
+import type { 
+  MatcherResult, 
+  MixedResult, 
+  ParsedSegment, 
+  XiConfig, 
+  Matcher, 
+  StoreConstructor, 
+  BaseStore 
+} from "./types.js"
+import { validateConfig } from './lib/config.js'
 
 /**
  * Equivalent character class - /^[a-zA-Z0-9_]$/

--- a/packages/xi/lib/config.ts
+++ b/packages/xi/lib/config.ts
@@ -1,5 +1,5 @@
-import { CONFIG } from './constants'
-import type { XiConfig } from '../types'
+import { CONFIG } from './constants.js'
+import type { XiConfig } from '../types.js'
 
 /**
  * Generic utility which merges two objects.

--- a/packages/xi/lib/exports/index.ts
+++ b/packages/xi/lib/exports/index.ts
@@ -1,3 +1,3 @@
-export { Node, Xi } from "../../index"
+export { Node, Xi } from "../../index.js"
 
-export type { BaseStore, StoreConstructor, XiConfig } from "../../types"
+export type { BaseStore, StoreConstructor, XiConfig } from "../../types.js"

--- a/packages/xin/index.ts
+++ b/packages/xin/index.ts
@@ -1,9 +1,9 @@
 import { Xi, Node, type BaseStore, type StoreConstructor } from "@xinkjs/xi"
-import { sequence } from "./lib/runtime/utils"
-import { validateConfig } from "./lib/config"
-import { addCookiesToHeaders, getCookies, isFormContentType, redirectResponse, resolve } from "./lib/runtime/fetch"
-import { json, text, html, redirect, Redirect } from './lib/runtime/helpers'
-import { openapi_template } from "./lib/runtime/openapi"
+import { sequence } from "./lib/runtime/utils.js"
+import { validateConfig } from "./lib/config.js"
+import { addCookiesToHeaders, getCookies, isFormContentType, redirectResponse, resolve } from "./lib/runtime/fetch.js"
+import { json, text, html, redirect, Redirect } from './lib/runtime/helpers.js'
+import { openapi_template } from "./lib/runtime/openapi.js"
 import type { 
   BasicRouteInfo,
   Cookie,
@@ -19,7 +19,7 @@ import type {
   OpenApiOptions,
   SchemaDefinition,
   XinConfig
-} from "./types"
+} from "./types.js"
 import { HANDLER_METHODS, HOOK_METHODS } from "./lib/constants.js"
 
 export class Store<Path extends string = string, ReqSchema extends SchemaDefinition = SchemaDefinition, ResSchema = unknown> implements BaseStore {

--- a/packages/xin/lib/config.ts
+++ b/packages/xin/lib/config.ts
@@ -1,5 +1,5 @@
-import type { XinConfig } from '../types'
-import { CONFIG } from './constants'
+import type { XinConfig } from '../types.js'
+import { CONFIG } from './constants.js'
 
 /**
  * Generic utility which merges two objects.

--- a/packages/xin/lib/exports/index.ts
+++ b/packages/xin/lib/exports/index.ts
@@ -1,11 +1,11 @@
-export { html, json, redirect, text, StandardSchemaError } from '../runtime/helpers'
-export { Xin } from '../../index'
+export { html, json, redirect, text, StandardSchemaError } from '../runtime/helpers.js'
+export { Xin } from '../../index.js'
 
 export type { 
   Handle,
   Handler,
   Hook,
   RequestEvent
-} from '../../types'
+} from '../../types.js'
 
 export type { ApiReferenceConfiguration } from '@scalar/types'

--- a/packages/xin/lib/runtime/fetch.ts
+++ b/packages/xin/lib/runtime/fetch.ts
@@ -1,8 +1,8 @@
 import { parse, serialize, type ParseOptions, type SerializeOptions } from 'cookie'
-import { inferObjectValueTypes, isContentType } from './utils'
-import { DISALLOWED_METHODS } from '../constants'
-import { StandardSchemaError, json, text, html } from './helpers'
-import { isVNode, renderToString } from "./jsx"
+import { inferObjectValueTypes, isContentType } from './utils.js'
+import { DISALLOWED_METHODS } from '../constants.js'
+import { StandardSchemaError, json, text, html } from './helpers.js'
+import { isVNode, renderToString } from "./jsx.js"
 import type { 
   Cookie,
   Cookies,
@@ -10,7 +10,7 @@ import type {
   HookMethod,
   ResolveEvent,
   StandardSchemaV1
-} from '../../types'
+} from '../../types.js'
 
 /* ATTR: SvelteKit */
 export const addCookiesToHeaders = (headers: Headers, cookies: Cookie[]) => {

--- a/packages/xin/lib/runtime/helpers.ts
+++ b/packages/xin/lib/runtime/helpers.ts
@@ -1,4 +1,4 @@
-import type { ResponseT } from "../../types"
+import type { ResponseT } from "../../types.js"
 
 export class StandardSchemaError extends Error {
   constructor(message: string, options?: ErrorOptions) {

--- a/packages/xin/lib/runtime/utils.ts
+++ b/packages/xin/lib/runtime/utils.ts
@@ -1,4 +1,4 @@
-import type { Handle, MaybePromise, RequestEvent } from "../../types"
+import type { Handle, MaybePromise, RequestEvent } from "../../types.js"
 
 /* ATTR: SvelteKit */
 export function sequence(...handlers: Handle[]): Handle {

--- a/packages/xin/types.ts
+++ b/packages/xin/types.ts
@@ -2,7 +2,7 @@ import type { BaseStore, XiConfig } from "@xinkjs/xi"
 import type { SerializeOptions, ParseOptions } from 'cookie'
 import type { ApiReferenceConfiguration } from '@scalar/types'
 import type { OpenAPIV3 } from "@scalar/types"
-import type { html, redirect, text } from "./lib/runtime/helpers"
+import type { html, redirect, text } from "./lib/runtime/helpers.js"
 import type { JSXNode } from "./lib/runtime/jsx.js"
 
 declare global {


### PR DESCRIPTION
- fix: imports, so that you can hopefully use node-style tsconfig.json options and still get types in code editors.