### PR TITLE
fix: handle HEAD with GET

### DIFF
--- a/.changeset/legal-bikes-slide.md
+++ b/.changeset/legal-bikes-slide.md
@@ -1,0 +1,5 @@
+---
+"@xinkjs/xin": patch
+---
+
+Handle HEAD request via GET handler


### PR DESCRIPTION
Per RFC 9110, properly handles HEAD requests with a `get` or `fallback` handler.

Also sets a `content-length` header of `0` for null or undefined responses from handlers.